### PR TITLE
Resolved the ID issue

### DIFF
--- a/service/resources/recommendation_collection.py
+++ b/service/resources/recommendation_collection.py
@@ -62,7 +62,7 @@ class RecommendationCollection(Resource):
             app.logger.info(message)
             abort(status.HTTP_400_BAD_REQUEST, message)
 
-        recommendation = Recommendation()
+        recommendation = Recommendation(data["id"])
         try:
             recommendation.deserialize(data)
         except DataValidationError as error:

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -25,43 +25,45 @@ class TestRecommendations(unittest.TestCase):
 		Recommendation.remove_all()
 		sleep(0.5)
 
-	def test_create_a_recommendation(self): 
-		recommendation = Recommendation("productId", "suggestionId", "categoryId")
+	def test_create_a_recommendation(self):
+		recommendation = Recommendation(1, "productId", "suggestionId", "categoryId")
 		self.assertNotEqual(recommendation, None)
-		self.assertEqual(recommendation.id, None)
+		self.assertEqual(recommendation.id, 1)
 		self.assertEqual(recommendation.productId, "productId")
 		self.assertEqual(recommendation.suggestionId, "suggestionId")
 		self.assertEqual(recommendation.categoryId, "categoryId")
 
-	def test_delete_a_recommendation(self): 
-		recommendation = Recommendation("productId", "recommended", "categoryId")
+	def test_delete_a_recommendation(self):
+		recommendation = Recommendation(1, "productId", "recommended", "categoryId")
 		recommendation.save()
 		self.assertEqual(len(Recommendation.all()), 1)
 		recommendation.delete()
 		self.assertEqual(len(Recommendation.all()), 0)
 
 	def test_serialize_a_recommendation(self):
-		recommendation = Recommendation("iPhone", "Pixel", "Digital Prodct")
+		recommendation = Recommendation(1,"iPhone", "Pixel", "Digital Prodct")
 		data = recommendation.serialize()
 		self.assertNotEqual(data, None)
 		self.assertNotIn('_id', data)
+		self.assertEqual(data['id'], 1)
 		self.assertEqual(data['productId'], "iPhone")
 		self.assertEqual(data['suggestionId'], "Pixel")
 		self.assertEqual(data['categoryId'], "Digital Prodct")
 
 	def test_deserialize_a_recommendation(self):
-		data = {"productId": "iPhone", "suggestionId": "Pixel", "categoryId": "Digital Prodct"}
-		recommendation = Recommendation()
+		data = {"id": 1, "productId": "iPhone", "suggestionId": "Pixel", "categoryId": "Digital Prodct"}
+		recommendation = Recommendation(id=data["id"])
 		recommendation.deserialize(data)
 		self.assertNotEqual(recommendation, None)
-		self.assertEqual(recommendation.id, None) 
+		self.assertEqual(recommendation.id, 1)
 		self.assertEqual(recommendation.productId, "iPhone")
 		self.assertEqual(recommendation.suggestionId, "Pixel")
 		self.assertEqual(recommendation.categoryId, "Digital Prodct")
 
 	def test_deserialize_with_no_productId(self):
-		recommendation = Recommendation()
-		data = {"suggestionId": "Pixel", "categoryId": "Digital Prodct"}
+		#recommendation = Recommendation()
+		data = {"id":1, "suggestionId": "Pixel", "categoryId": "Digital Prodct"}
+		recommendation = Recommendation(id=data["id"])
 		self.assertRaises(DataValidationError, recommendation.deserialize, data)
 
 	def test_deserialize_with_no_data(self):
@@ -73,7 +75,7 @@ class TestRecommendations(unittest.TestCase):
 		self.assertRaises(DataValidationError, recommendation.deserialize, "string data")
 
 	def test_find_a_recommendation(self):
-		saved_recommendation = Recommendation("productId", "recommended", "categoryId")
+		saved_recommendation = Recommendation(1, "productId", "recommended", "categoryId")
 		saved_recommendation.save()
 		recommendation = Recommendation.find(saved_recommendation.id)
 		self.assertEqual(recommendation.productId, "productId")
@@ -82,7 +84,7 @@ class TestRecommendations(unittest.TestCase):
 		self.assertEqual(recommendation.productId, "productId")
 
 	def test_update_a_recommendation(self):
-		recommendation = Recommendation("productId", "recommended", "categoryId")
+		recommendation = Recommendation(1, "productId", "recommended", "categoryId")
 		recommendation.save()
 
 		recommendation.categoryId = "newcategoryId"
@@ -90,16 +92,16 @@ class TestRecommendations(unittest.TestCase):
 		recommendations = Recommendation.all()
 		self.assertEqual(recommendations[0].categoryId, "newcategoryId")
 
-	def test_find_by_categoryId(self): 
-		Recommendation("productId1", "recommended1", "categoryId1").save()
-		Recommendation("productId2", "recommended2", "categoryId2").save()
+	def test_find_by_categoryId(self):
+		Recommendation(1,"productId1", "recommended1", "categoryId1").save()
+		Recommendation(2, "productId2", "recommended2", "categoryId2").save()
 		recommendations = Recommendation.find_by_categoryId("categoryId1")
 		self.assertEqual(len(recommendations), 1)
 		self.assertEqual(recommendations[0].categoryId, "categoryId1")
 
-	def test_find_by_suggestionId(self): 
-		Recommendation("productId1", "suggestionId1", "categoryId1").save()
-		Recommendation("productId2", "suggestionId2", "categoryId2").save()
+	def test_find_by_suggestionId(self):
+		Recommendation(1, "productId1", "suggestionId1", "categoryId1").save()
+		Recommendation(2, "productId2", "suggestionId2", "categoryId2").save()
 		recommendations = Recommendation.find_by_suggestionId("suggestionId1")
 		self.assertEqual(len(recommendations), 1)
 		self.assertEqual(recommendations[0].suggestionId, "suggestionId1")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -45,9 +45,9 @@ class TestRecommendationService(unittest.TestCase):
         sleep(0.5)
         Recommendation.remove_all()
         sleep(0.5)
-        Recommendation(productId='Infinity Gauntlet', suggestionId='Soul Stone', categoryId='Comics').save()
+        Recommendation(id=1, productId='Infinity Gauntlet', suggestionId='Soul Stone', categoryId='Comics').save()
         sleep(0.5)
-        Recommendation(productId='iPhone', suggestionId='iphone Case', categoryId='Electronics').save()
+        Recommendation(id=2, productId='iPhone', suggestionId='iphone Case', categoryId='Electronics').save()
         sleep(0.5)
 
     def tearDown(self):
@@ -67,7 +67,7 @@ class TestRecommendationService(unittest.TestCase):
     def test_get_recommendation(self):
         # self.assertEqual(self.get_recommendation_count(), 2)
         recommendation = self.get_recommendation('iPhone')[0]
-        resp = self.app.get('/recommendations/{}'.format(recommendation['_id']))
+        resp = self.app.get('/recommendations/2')
         self.assertEqual(resp.status_code, HTTP_200_OK)
         data = json.loads(resp.data)
         self.assertEqual(data['suggestionId'], 'iphone Case')
@@ -77,7 +77,7 @@ class TestRecommendationService(unittest.TestCase):
         self.assertEqual(resp.status_code, HTTP_404_NOT_FOUND)
 
     def test_create_recommendation(self):
-        new_recommenation = dict(productId='Table', suggestionId='Chair', categoryId='Home Appliances')
+        new_recommenation = dict(id=3, productId='Table', suggestionId='Chair', categoryId='Home Appliances')
         data = json.dumps(new_recommenation)
         resp = self.app.post('/recommendations', data=data, content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
@@ -108,13 +108,13 @@ class TestRecommendationService(unittest.TestCase):
         recommendation = self.get_recommendation('iPhone')[0]
         new_recommedation = dict(productId='iPhone', suggestionId='iphone pop ups', categoryId='Electronics')
         data = json.dumps(new_recommedation)
-        resp = self.app.put('/recommendations/{}'.format(recommendation['_id']), data=data, content_type='application/json')
+        resp = self.app.put('/recommendations/2', data=data, content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         new_json = json.loads(resp.data)
         self.assertEqual(new_json['suggestionId'], 'iphone pop ups')
 
     def test_update_recommendation_not_found(self):
-        new_reco = dict(productId='samsung', suggestionId='samsung pop ups', categoryId='Electronocs')
+        new_reco = dict(id=3,productId='samsung', suggestionId='samsung pop ups', categoryId='Electronocs')
         data = json.dumps(new_reco)
         invalidId = "123"
         recommendation = self.get_recommendation('iPhone')[0]
@@ -147,7 +147,7 @@ class TestRecommendationService(unittest.TestCase):
         recommendation_count = self.get_recommendation_count()
         # delete a recommendation
         recommendation = self.get_recommendation('iPhone')[0]
-        resp = self.app.delete('/recommendations/{}'.format(recommendation['_id']), content_type='application/json')
+        resp = self.app.delete('/recommendations/2', content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(len(resp.data), 0)
         new_count = self.get_recommendation_count()


### PR DESCRIPTION
I was able to resolve the bug with ID. Now if we add a new recommendation with below data
{
	"id": 1
         "productId": "infinity gauntlet", 
	"suggestionId": "soul stone",
	"categoryId": "comics",
}

the id column will be 1. Previously the id would be added to the database with a hash value like daea4b731c7765fcd145ead067019122